### PR TITLE
chore(docs): project links updated to README view

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,22 +12,22 @@ title: What is in ORBIT?
 flowchart TD
     subgraph Orbit
     Baseline(Security Baseline)
-    click Baseline "https://github.com/ossf/security-baseline"
+    click Baseline "https://github.com/ossf/security-baseline?tab=readme-ov-file#readme"
     Gemara(Gemara)
-    click Gemara "https://github.com/ossf/gemara"
+    click Gemara "https://github.com/ossf/gemara?tab=readme-ov-file#readme"
     SecurityInsights(Security Insights)
-    click SecurityInsights "https://github.com/ossf/security-insights"
+    click SecurityInsights "https://github.com/ossf/security-insights?tab=readme-ov-file#readme"
     Minder(Minder)
-    click Minder "https://github.com/mindersec/minder"
+    click Minder "https://github.com/mindersec/minder?tab=readme-ov-file#readme"
     Minder -->|Evaluates| minder-rules(minder-rules)
-    click minder-rules "https://github.com/mindersec/minder-rules-and-profiles"
+    click minder-rules "https://github.com/mindersec/minder-rules-and-profiles?tab=readme-ov-file#readme"
     minder-rules -->|Expresses| Baseline
     minder-rules -->|Reads| SecurityInsights
     Assessments(Security Assessments)
-    click Assessments "https://github.com/ossf/security-assessments"
+    click Assessments "https://github.com/ossf/security-assessments?tab=readme-ov-file#readme"
     Gemara -->|Expresses| Baseline
     pvtr(pvtr-github-repo) -->|Uses | Gemara
-    click pvtr "https://github.com/revanite-io/pvtr-github-repo"
+    click pvtr "https://github.com/revanite-io/pvtr-github-repo?tab=readme-ov-file#readme"
     pvtr -->|Consumes | SecurityInsights
     pvtr -->|Produces | AssessmentResults(Gemara Layer 4)
     click AssessmentResults "https://github.com/ossf/gemara?tab=readme-ov-file#layer-4-evaluation"


### PR DESCRIPTION
This change improves the experience of a visitor clicking through the diagram links by taking them directly to the README view, rather than landing them at the default repo view, forcing them to scroll to read the relevant README content.