### PR TITLE
Classify Minder as a Technical Initiative

### DIFF
--- a/CHARTER.md
+++ b/CHARTER.md
@@ -67,6 +67,7 @@ This Technical Charter sets forth the responsibilities and procedures for techni
 | [Security Insights Specification](https://github.com/ossf/security-insights-spec) | Eddie Knight (@eddie-knight) |
 | [Gemara](https://github.com/ossf/gemara) | Jennifer Power (@jpower432) |
 | [ORBIT Launchpad](https://github.com/ossf/orbit-launchpad) | Nicole Bates (@nikcal) |
+| [Minder](https://github.com/mindersec) | Evan Anderson (@evankanderson) |
 
 ### Inactive Technical Initiatives
 


### PR DESCRIPTION
Minder was previously categorized under the ORBIT Tooling SIG, which continued after the SIG was rechartered as ORBIT Launchpad.

In that time, it has been operating independently without any material input or coordination from either parent SIG. As such, I'm proposing that we reclassify it as a top-level ORBIT Technical Initiative. 

If accepted, this will result in an additional voting member of the ORBIT TSC.